### PR TITLE
Switched from name to reference for vpc network in order to solve concurrency

### DIFF
--- a/examples/tf-shared-vpc-backend-access/main.tf
+++ b/examples/tf-shared-vpc-backend-access/main.tf
@@ -32,4 +32,6 @@ module "serverless_endpoint" {
   shared_vpc_host_project = var.shared_vpc_host_project
   shared_vpc_host_connector_name = google_compute_subnetwork.shared-vpc-host-connector.name
   source_ip_range_for_security_policy = var.source_ip_range_for_security_policy
+  
+  shared_vpc_self_link = google_compute_network.shared-vpc-host.self_link
 }

--- a/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/main.tf
+++ b/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/main.tf
@@ -220,7 +220,7 @@ resource "google_vpc_access_connector" "connector" {
 resource "google_compute_firewall" "serverless-to-vpc-connector" {
   project = var.shared_vpc_host_project
   name    = "${var.name}-fw-shared-vpc-serverless-to-vpc-connector"
-  network = var.shared_vpc_host_name
+  network = var.shared_vpc_self_link
 
   target_tags = ["vpc-connector"]
 
@@ -242,7 +242,7 @@ resource "google_compute_firewall" "serverless-to-vpc-connector" {
 resource "google_compute_firewall" "vpc-connector-to-serverless" {
   project = var.shared_vpc_host_project
   name    = "${var.name}-fw-shared-vpc-vpc-connector-to-serverless"
-  network = var.shared_vpc_host_name
+  network = var.shared_vpc_self_link
 
   target_tags = ["vpc-connector"]
 
@@ -281,7 +281,7 @@ resource "google_compute_firewall" "vpc-connector-health-checks" {
 resource "google_compute_firewall" "connector-access-to-vpc" {
   project = var.shared_vpc_host_project
   name    = "${var.name}-fw-connector-to-vpc"
-  network = var.shared_vpc_host_name
+  network = var.shared_vpc_self_link
 
   allow {
     protocol = "tcp"

--- a/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/variables.tf
+++ b/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/variables.tf
@@ -65,5 +65,5 @@ variable "shared_vpc_host_connector_name" {
 }
 variable "shared_vpc_self_link" {
   type        = string
-  description = "Shared VPC host connector name (created in networking.tf)"
+  description = "Shared VPC reference (created in networking.tf)"
 }

--- a/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/variables.tf
+++ b/examples/tf-shared-vpc-backend-access/modules/serverless_endpoint/variables.tf
@@ -63,3 +63,7 @@ variable "shared_vpc_host_connector_name" {
   type        = string
   description = "Shared VPC host connector name (created in networking.tf)"
 }
+variable "shared_vpc_self_link" {
+  type        = string
+  description = "Shared VPC host connector name (created in networking.tf)"
+}


### PR DESCRIPTION
There was a small problem, where terraform was trying to create fw rules for a network that didn't yet complete creation.